### PR TITLE
Kp824/fe itinerary card

### DIFF
--- a/server/controllers/gptController.ts
+++ b/server/controllers/gptController.ts
@@ -37,7 +37,7 @@ interface IRequestText {
 // https://github.com/openai/openai-node/blob/master/README.md
 export const getCompletion = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    console.log("REQBODY?", req.body);
+    //console.log("REQBODY?", req.body);
     // console.log('ID?', req.params.id)
     // if(cacheRead(req.params.id)) {
     //   console.log('READING CACHED RESPONSE')
@@ -95,7 +95,7 @@ ${JSON.stringify(req.body.Restaurants)}
     //   return res.status(400).json({ error: "Prompt is required" });
     // }
 
-    console.log(`PROMPT???`, api_prompt);
+    //console.log(`PROMPT???`, api_prompt);
 
     const completion = await openai.chat.completions.create({
       messages: [{ role: "user", content: api_prompt }],

--- a/server/controllers/pexelsController.ts
+++ b/server/controllers/pexelsController.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { Request, Response } from 'express';
-import { PEXELS_API_KEY } from '../config.js';
+import { PEXELS_API_KEY, RAPIDAPI_KEY } from '../config.js';
 
 interface PexelsPhotoSrc {
   original: string;
@@ -45,7 +45,7 @@ export const searchPhotos = async (req: Request, res: Response) => {
     params: { query, locale, per_page: perPage, page },
     headers: {
       Authorization: PEXELS_API_KEY,
-      'X-RapidAPI-Key': PEXELS_API_KEY,
+      'X-RapidAPI-Key': RAPIDAPI_KEY,
       'X-RapidAPI-Host': 'PexelsdimasV1.p.rapidapi.com',
     },
   };

--- a/server/controllers/yelpController.ts
+++ b/server/controllers/yelpController.ts
@@ -23,8 +23,8 @@ export const getRestaurants = async (req: Request, res: Response, next: NextFunc
     const response = await fetch(apiUrl, { method: 'GET', headers });
     const restaurantData = await response.json(); // Parse the JSON response
 
-    //console.log('yelp response:', restaurantData);
-
+    console.log('yelp response:', restaurantData);
+    //@ts-ignore
     res.locals.restaurants = restaurantData;
     return next();
   } catch (error) {

--- a/server/controllers/yelpController.ts
+++ b/server/controllers/yelpController.ts
@@ -6,7 +6,7 @@ import fetch from 'node-fetch';
 export const getRestaurants = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   const location = req.params.location;
 
-  console.log('LOCATION?', location)
+  //console.log('LOCATION?', location)
 
   if (!location) {
     res.status(400).send('Location query parameter is required.');
@@ -23,7 +23,7 @@ export const getRestaurants = async (req: Request, res: Response, next: NextFunc
     const response = await fetch(apiUrl, { method: 'GET', headers });
     const restaurantData = await response.json(); // Parse the JSON response
 
-    console.log('yelp response:', restaurantData);
+    //console.log('yelp response:', restaurantData);
     //@ts-ignore
     res.locals.restaurants = restaurantData;
     return next();

--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -9,6 +9,9 @@ import axiosInstance from '../axiosInstance';
 import parseGPTResponse from '../../utils/parseGPTresponse';
 import CircularProgress from '@mui/material/CircularProgress';
 import ItineraryCard from './ItineraryCard';
+import MockItineraryData from './MockData2';
+
+const data = MockItineraryData;
 
 const ItineraryContainer = styled.div`
   display: flex;
@@ -66,6 +69,21 @@ const GptResponseContainer = styled.div`
   overflow-y: auto;
 `;
 
+// Define interfaces for the expected data structure
+interface ParsedResponse {
+  [day: string]: {
+    Morning?: string[];
+    Afternoon?: string[];
+    Evening?: string[];
+  };
+}
+
+interface GroupedItinerary {
+  [day: string]: {
+    timeOfDay: string;
+    activities: string[];
+  }[];
+}
 
 
 
@@ -82,7 +100,7 @@ const Itinerary = () => {
   }
 
   useEffect(() => {
-    console.log(`Before fetch pexel call`);
+    //console.log(`Before fetch pexel call`);
     const fetchPexelPics = async () => {
       try{
         const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
@@ -96,19 +114,25 @@ const Itinerary = () => {
     fetchPexelPics();
   }, [])
 
-  const [parsedResponse, setParsedResponse] = useState();
-  const { gptResponse } = useStore();
+  // Adjustment here
+  const [parsedResponse, setParsedResponse] = useState<ParsedResponse | null>(null);
+  // Commenting out to use mock data instead of data from store:
+  // const { gptResponse } = useStore();
+
+  const gptResponse = JSON.stringify(data);
 
   React.useEffect(() => {
     setParsedResponse(parseGPTResponse(gptResponse));
   }, [gptResponse]);
 
-  const groupedItinerary = {};
+  // Adjustment here
+  const groupedItinerary: GroupedItinerary = {};
 
   if (parsedResponse) {
     for (const day of Object.keys(parsedResponse)) {
       for (const timeOfDay of ['Morning', 'Afternoon', 'Evening']) {
-        const activities = parsedResponse[day][timeOfDay];
+        // Adjustment here
+        const activities = (parsedResponse[day] as { [key: string]: string[] })[timeOfDay];
         if (activities && activities.length > 0) {
           if (!groupedItinerary[day]) {
             groupedItinerary[day] = [];
@@ -136,8 +160,6 @@ const Itinerary = () => {
           )}
         </Slide>
         
-        
-        {/* <TripImg src="https://images.pexels.com/photos/460672/pexels-photo-460672.jpeg" alt="London Bridge" /> */}
         
         <br />
         <br />
@@ -176,3 +198,6 @@ const Itinerary = () => {
 
 
 export default Itinerary;
+
+
+//{/* <TripImg src="https://images.pexels.com/photos/460672/pexels-photo-460672.jpeg" alt="London Bridge" /> */}

--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -8,6 +8,7 @@ import { PartialStore } from '../../types';
 import axiosInstance from '../axiosInstance';
 import parseGPTResponse from '../../utils/parseGPTresponse';
 import CircularProgress from '@mui/material/CircularProgress';
+import ItineraryCard from './ItineraryCard';
 
 const ItineraryContainer = styled.div`
   display: flex;
@@ -47,6 +48,7 @@ const PexelImg = styled.img`
   height: 100%;
   object-fit: cover;
 `;
+
 const GptResponseContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -80,9 +82,10 @@ const Itinerary = () => {
   }
 
   useEffect(() => {
+    console.log(`Before fetch pexel call`);
     const fetchPexelPics = async () => {
       try{
-        const pexelsResponse = await axiosInstance.get(`/pexels?query=$(useStore.getState().location}`);
+        const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
         // save response data to store
         setPexelPics(pexelsResponse.data.photos);
   
@@ -132,6 +135,36 @@ const Itinerary = () => {
             <p>Loading images...</p>
           )}
         </Slide>
+        
+        
+        {/* <TripImg src="https://images.pexels.com/photos/460672/pexels-photo-460672.jpeg" alt="London Bridge" /> */}
+        
+        <br />
+        <br />
+
+        <GptResponseContainer>
+          {Object.keys(groupedItinerary).length === 0 ? (
+            <>
+              <h1>Loading your itinerary...</h1>
+              <CircularProgress />
+            </>
+          ) : (
+            <>
+              {Object.keys(groupedItinerary).map((day) => (
+                <div key={day}>
+                  {groupedItinerary[day].map((data, index) => (
+                    <ItineraryCard
+                      key={`${day}-${data.timeOfDay}-${index}`}
+                      day={index === 0 ? day : ''}
+                      timeOfDay={data.timeOfDay}
+                      activities={data.activities}
+                    />
+                  ))}
+                </div>
+              ))}
+            </>
+          )}
+        </GptResponseContainer>
         
       </TripImagesContainer>
 

--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -1,5 +1,11 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
+import { Slide } from 'react-slideshow-image';
+import 'react-slideshow-image/dist/styles.css';
+import { PexelPic } from '../../types';
+import useStore from '../store';
+import { PartialStore } from '../../types';
+import axiosInstance from '../axiosInstance';
 
 const ItineraryContainer = styled.div`
   display: flex;
@@ -22,7 +28,7 @@ const ItineraryContainer = styled.div`
   }
 `;
 
-const TripImage = styled.div`
+const TripImagesContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -30,6 +36,7 @@ const TripImage = styled.div`
   height: 250px;
   position: relative;
 `;
+
 
 const PexelImg = styled.img`
   position: absolute;
@@ -41,17 +48,49 @@ const PexelImg = styled.img`
 `;
 
 
-
-
-
 const Itinerary = () => {
+
+  const {pexelPics, setPexelPics} : PartialStore = useStore();
+
+  const slideshowProperties = {
+    autoplay: true, // 
+    duration: 5000, // Set to 0 to turn off auto slide
+    transitionDuration: 500,
+    indicators: true,
+    infinite: true,
+    canSwipe: true,
+  }
+
+  useEffect(() => {
+    const fetchPexelPics = async () => {
+      try{
+        const pexelsResponse = await axiosInstance.get(`/pexels?query=$(useStore.getState().location}`);
+        // save response data to store
+        setPexelPics(pexelsResponse.data.photos);
+  
+      } catch(error) {
+        console.log(`Error fetching pexel pics: ${error}`);
+      }
+    };
+    fetchPexelPics();
+  }, [])
+  
 
   return (
     <ItineraryContainer>
       
-      <TripImage>
-        <PexelImg src="https://images.pexels.com/photos/460672/pexels-photo-460672.jpeg" alt="London Bridge"/>
-      </TripImage>
+      <TripImagesContainer>
+        <Slide easing="ease" {...slideshowProperties}>
+          {pexelPics !== null ? (
+            pexelPics.map((pexelPic: PexelPic) => (
+              <PexelImg src={pexelPic.url} alt={pexelPic.alt} />
+            ))
+          ) : (
+            <p>Loading images...</p>
+          )}
+        </Slide>
+        
+      </TripImagesContainer>
 
       <h1>Your next vacation</h1>
 
@@ -60,5 +99,6 @@ const Itinerary = () => {
     </ItineraryContainer>
   )
 };
+
 
 export default Itinerary;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -5,22 +5,7 @@ import styled from 'styled-components';
 import "./renderMap.css"
 import useStore from '../store';
 
-// const MapCont = styled.div`
-//     display: flex;
-//     justify-content: center;
-//     align-items: center;
-//     border-radius: 20px;
-//     border: 1px solid black;
-//     width: 100%;
-//     min-height: 300px;
-//     min-width: 300px;
-//     transition: transform 0.3s ease-in-out;
-// `;
 
-// const StyledGoogleMap = styled(GoogleMap)`
-//   width: 100%;
-//   height: 100%;
-// `;
 
 export default function Map(): React.ReactElement {
     type PartialStore = {
@@ -43,7 +28,8 @@ export default function Map(): React.ReactElement {
     useEffect(() => {
         const viewportHeight = window.innerHeight;
         document.getElementById("map-container")!.style.height = `${viewportHeight - 140}px`;
-        console.log(`viewport: ${viewportHeight}`);
+        //console.log(`viewport: ${viewportHeight}`);
+        //console.log(`check here:`, restaurants)
     }, []);
 
     const handleMarkerClick = (restaurant: any) => {
@@ -77,11 +63,11 @@ export default function Map(): React.ReactElement {
                     />
 
                     {/* Restaurant markers */}
-                    {restaurants.map((restaurant) => (
+                    {restaurants.map((internalRestaurant) => (
                         <Marker
-                            key={restaurant.id}
-                            position={{ lat: restaurant.latitude, lng: restaurant.longitude }}
-                            onClick={() => handleMarkerClick(restaurant)}
+                            key={internalRestaurant.id}
+                            position={{ lat: internalRestaurant.latitude, lng: internalRestaurant.longitude }}
+                            onClick={() => handleMarkerClick(internalRestaurant)}
                         />
                     ))}
 
@@ -106,3 +92,21 @@ export default function Map(): React.ReactElement {
         </div>
     );
 }
+
+
+// const MapCont = styled.div`
+//     display: flex;
+//     justify-content: center;
+//     align-items: center;
+//     border-radius: 20px;
+//     border: 1px solid black;
+//     width: 100%;
+//     min-height: 300px;
+//     min-width: 300px;
+//     transition: transform 0.3s ease-in-out;
+// `;
+
+// const StyledGoogleMap = styled(GoogleMap)`
+//   width: 100%;
+//   height: 100%;
+// `;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -4,6 +4,9 @@ import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import "./renderMap.css"
 import useStore from '../store';
+import MockData from './MockData';
+
+const data = MockData;
 
 
 
@@ -62,14 +65,25 @@ export default function Map(): React.ReactElement {
                         }}
                     />
 
+                    {/* Using Mock Data to render map markers */}
+                    {data.map((internalRestaurant) => (
+                        <Marker
+                        key={internalRestaurant.id}
+                        position={{ lat: internalRestaurant.latitude, lng: internalRestaurant.longitude }}
+                        onClick={() => handleMarkerClick(internalRestaurant)}
+                    />
+                    ))}
+
+
+                    {/* Need to comment out to use Mock Data to render markers instead
                     {/* Restaurant markers */}
-                    {restaurants.map((internalRestaurant) => (
+                    {/* {restaurants.map((internalRestaurant) => (
                         <Marker
                             key={internalRestaurant.id}
                             position={{ lat: internalRestaurant.latitude, lng: internalRestaurant.longitude }}
                             onClick={() => handleMarkerClick(internalRestaurant)}
                         />
-                    ))}
+                    ))} */}
 
                     {/* InfoWindow to display selected restaurant details */}
                     {selectedRestaurant && (

--- a/src/components/MockData2.tsx
+++ b/src/components/MockData2.tsx
@@ -1,0 +1,36 @@
+const MockItineraryData = {
+  "25.790654,-80.1300455 Travel Itinerary": 
+  {
+    "Duration": "2023-09-08 - 2023-09-10",
+    "Number of Travelers": 1,
+    "Budget": "$$$",
+    "Day 1: 2023-09-08": {
+      "Morning": [
+        "Start your day with a visit to the stunning South Beach. Explore the pristine sandy beach, soak up the sun, and take a refreshing dip in the crystal-clear waters. Capture some amazing photos to cherish the memories.",
+        "Afterward, head to the iconic Art Deco Historic District. Take a leisurely stroll down Ocean Drive, lined with colorful Art Deco buildings. Admire the unique architecture and learn about the rich history of the area."
+      ],
+      "Afternoon": [
+        "Treat yourself to a delicious lunch at OLA Restaurant, a well-known establishment located at 2360 Collins Ave. Indulge in their mouthwatering Latin American cuisine and savor the flavors of the region.",
+        "After lunch, satisfy your shopping desires at Lincoln Road Mall. This vibrant pedestrian street offers a wide range of shops, boutiques, and galleries. Browse through the latest fashion trends, pick up unique souvenirs, or enjoy a coffee at one of the cafes."
+      ],
+      "Evening": [
+        "Get ready to experience the vibrant nightlife Miami Beach has to offer! Start your evening with dinner at La Ventana Colombian Restaurant, situated at 710 Washington Ave. Enjoy authentic Colombian dishes and immerse yourself in the lively atmosphere.",
+        "After dinner, groove your way to Serena Rooftop, located at 915 Collins Ct. This trendy rooftop bar offers stunning views of the Miami skyline. Sip on refreshing cocktails, dance to vibrant music, and enjoy a memorable night out."
+      ],
+      "Additional Notes": [
+        "Don't forget to pack your sunscreen, beach essentials, and comfortable walking shoes.",
+        "It's always a good idea to make dinner reservations in advance, especially for popular restaurants.",
+        "Ensure you have a valid ID to access clubs and bars in the evening."
+      ]
+    },
+    "Special Occasions and Notes": [
+      "If you're interested in Cuban cuisine, consider visiting Havana 1957 Cuban Cuisine - Espanola Way at 405 Española Way. It has a great reputation and offers traditional Cuban dishes.",
+      "For a brunch experience, try Yardbird at 1600 Lenox Ave. They serve delectable Southern-inspired flavors and are known for their famous chicken and waffles.",
+      "If you prefer Italian cuisine, indulge in a delightful dinner at Il Pastaiolo, located at 1130 Collins Ave. Their homemade pasta dishes are exceptional."
+    ],
+  }
+};
+
+//"Enjoy your trip to 25.790654,-80.1300455, and make the most of your time exploring the beautiful city of Miami Beach!"
+
+export default MockItineraryData;

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -139,11 +139,11 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     // setMongoID(initialResponse.data);
                     break;
                 case 2:
-                    console.log(useStore.getState())
+                    console.log(`Inside case 2 of QuestionCard`,useStore.getState())
                     break;
                 case 3:
                     setArrivalDate(answer);
-                    console.log(useStore.getState())
+                    console.log(`Inside of case 3 of QuestionCard`,useStore.getState())
                     break;
                 case 4:
                     setEndDate(answer);
@@ -151,7 +151,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     // RESTURANT DATA - commented out to save calls
                     const restaurantResponse = await axiosInstance.get(`/yelp/${useStore.getState().location}`) as any
                     setRestaurants(restaurantResponse.data.data);
-                    console.log(useStore.getState())
+                    console.log(`Inside of case 4 of QuestionCard`, useStore.getState())
                     break;
             }
             // reveal the next card by changing the state
@@ -190,7 +190,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
             Restaurants: restaurants,
         }
 
-        console.log('COMPOSEDREQUEST', composedRequest)
+        //console.log('COMPOSEDREQUEST', composedRequest)
 
 
         const gptRes = async () => {

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -169,6 +169,8 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
     const sendToGpt = async (): Promise<void> => {
         setAdditionalNotes(answer)
 
+        console.log(`Checking if restaurants is an array within sendToGpt: ${useStore.getState()}`);
+
         const restaurants = useStore.getState().restaurants.map(restaurant => {
             return {
                 address: restaurant.address,

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -5,10 +5,8 @@ import { QuestionCardType } from "../../types";
 import { Link } from "react-router-dom";
 import { BaseButtonStyle } from "../GlobalStyles";
 import useStore from '../store';
-import {
-    PartialStore
-} from '../../types';
-import axiosInstance from '../axiosInstance'
+import { PartialStore } from '../../types';
+import axiosInstance from '../axiosInstance';
 import AutoComplete from "./AutoComplete";
 
 
@@ -86,29 +84,13 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
 
     // store and reducers
     const {
-        numOfTravellers,
         setNumberOfTravellers,
-        arrivalDate,
         setArrivalDate,
-        endDate,
         setEndDate,
-        infoForWeather,
-        setInfoForWeather,
-        yelpBudget,
         setYelpBudget,
-        location,
-        setLocationAsString,
-        additionalNotes,
         setAdditionalNotes,
-        initialData,
-        setInitialData,
-        mongoID,
-        setMongoID,
-        gptResponse,
         setGptResponse,
-        responseId,
         setResponseId,
-        restaurants,
         setRestaurants,
     } : PartialStore = useStore();
     
@@ -197,6 +179,9 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     setRestaurants(restaurantResponse.data.data);
                     console.log(useStore.getState())
 
+                    // send pexel api request
+
+
 
                     break;
             }
@@ -236,6 +221,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
         }
 
         console.log('COMPOSEDREQUEST', composedRequest)
+
 
         const gptRes = async () => {
             try{

--- a/src/components/RestaurantCard.tsx
+++ b/src/components/RestaurantCard.tsx
@@ -13,8 +13,6 @@ const RestaurantCardContainer = styled.div`
   min-width: 400px;
 `;
 
-// border: 1px solid black;  Even out edges on cards
-
 const InnerCardContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -34,8 +32,6 @@ const ImgContainer = styled.div`
   padding-top: calc(100% * 1/2);
   position: relative;
 `;
-//
-// height: 100%;
 
 const RestaurantImg = styled.img`
   position: absolute;
@@ -62,8 +58,6 @@ const TextShadow = styled.div`
   background-color: whitesmoke;
   z-index: 1;
   padding: 15px;
-  
-  
 `;
 
 

--- a/src/components/RestaurantCard.tsx
+++ b/src/components/RestaurantCard.tsx
@@ -12,6 +12,7 @@ const RestaurantCardContainer = styled.div`
   min-height: 300px;
   min-width: 400px;
 `;
+
 // border: 1px solid black;  Even out edges on cards
 
 const InnerCardContainer = styled.div`

--- a/src/components/Restaurants.tsx
+++ b/src/components/Restaurants.tsx
@@ -7,6 +7,9 @@ import 'react-slideshow-image/dist/styles.css';
 import { Restaurant } from '../../types';
 import useStore from '../store';
 import { PartialStore } from '../../types';
+import MockData from './MockData';
+
+const data = MockData;
 
 
 const RestaurantContainer = styled.div`
@@ -52,6 +55,7 @@ const Restaurants = () => {
     canSwipe: true,
   };
 
+  // Commented out because we're fetching from yelp within QuestionCard component. Check Case #4
   // useEffect(() => {
   //   const fetchRestaurants = async () => {
   //     try {
@@ -73,13 +77,21 @@ const Restaurants = () => {
         
         <SlideshowContainer>
           <Slide easing="ease" {...slideshowProperties}>
+
+            {/* Using Mock data here to save API calls */}
+            {data.map((restaurant: Restaurant) => (
+              <RestaurantCard key={restaurant.id} restaurant={restaurant} />
+            ))}
+
+            {/* Commented out to use MockData instead
             {restaurants !== null ? (
               restaurants.map((restaurant: Restaurant) => (
                 <RestaurantCard key={restaurant.id} restaurant={restaurant} />
               ))
             ) : (
               <div>Loading restaurants...</div>
-            )}
+            )} */}
+
           </Slide>
         </SlideshowContainer>
           

--- a/src/components/Restaurants.tsx
+++ b/src/components/Restaurants.tsx
@@ -2,17 +2,12 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import axiosInstance from '../axiosInstance';
 import RestaurantCard from './RestaurantCard';
-import MockData from './MockData';
 import { Slide } from 'react-slideshow-image';
 import 'react-slideshow-image/dist/styles.css';
 import { Restaurant } from '../../types';
 import useStore from '../store';
 import { PartialStore } from '../../types';
 
-
-//const data = MockData;
-
-type ScrollWidth = number;
 
 const RestaurantContainer = styled.div`
   display: flex;
@@ -29,21 +24,11 @@ const RestaurantContainer = styled.div`
   overflow: hidden;
 
   transition: transform 0.3s ease-in-out;
-
   &:hover {
     transform: scale(1.05);
   }
 `;
 
-// const OutterCardContainer = styled.div<{ scrollOffset: number}>`
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   width: 100%;
-//   min-height: 300px;
-//   min-width: 300px;
-
-// `;
 
 const SlideshowContainer = styled.div`
   width: 100%;
@@ -67,28 +52,25 @@ const Restaurants = () => {
     canSwipe: true,
   };
 
-  useEffect(() => {
-    const fetchRestaurants = async () => {
-      try {
-        const restaurantRes = await axiosInstance.get(`/api/yelp/${location}`);
-        setRestaurants(restaurantRes.data);
-      } catch (error) {
-        console.error('Error fetching restaurants: ', error);
-      }
-    };
+  // useEffect(() => {
+  //   const fetchRestaurants = async () => {
+  //     try {
+  //       const restaurantRes = await axiosInstance.get(`/yelp/${useStore.getState().location}`);
+  //       setRestaurants(restaurantRes.data);
+  //     } catch (error) {
+  //       console.error('Error fetching restaurants: ', error);
+  //     }
+  //   };
 
-    fetchRestaurants();
+  //   fetchRestaurants();
 
-    console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
-  }, []);
+    //console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
+    //console.log(`RESTAURANTS?`, Array.isArray(restaurants))
+  // }, []);
 
   return (
       <RestaurantContainer>
-      
-        {/* {restaurantData.map((restaurant, index) => (
-          <RestaurantCard key={restaurant.id} restaurant={restaurant} />
-        ))} */}
-        {/* <OutterCardContainer scrollOffset={scrollOffset}> */}
+        
         <SlideshowContainer>
           <Slide easing="ease" {...slideshowProperties}>
             {restaurants !== null ? (
@@ -96,12 +78,10 @@ const Restaurants = () => {
                 <RestaurantCard key={restaurant.id} restaurant={restaurant} />
               ))
             ) : (
-              <p>Loading restaurants...</p>
+              <div>Loading restaurants...</div>
             )}
           </Slide>
         </SlideshowContainer>
-          
-        {/* </OutterCardContainer> */}
           
       </RestaurantContainer>
     
@@ -109,3 +89,24 @@ const Restaurants = () => {
 };
 
 export default Restaurants;
+
+
+//import MockData from './MockData';
+//const data = MockData;
+// type ScrollWidth = number;
+
+// const OutterCardContainer = styled.div<{ scrollOffset: number}>`
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   width: 100%;
+//   min-height: 300px;
+//   min-width: 300px;
+// `;
+
+{/* {restaurantData.map((restaurant, index) => (
+          <RestaurantCard key={restaurant.id} restaurant={restaurant} />
+        ))} */}
+//{/* <OutterCardContainer scrollOffset={scrollOffset}> */}  
+
+//{/* </OutterCardContainer> */}

--- a/src/components/Restaurants.tsx
+++ b/src/components/Restaurants.tsx
@@ -55,8 +55,8 @@ const SlideshowContainer = styled.div`
 
 
 const Restaurants = () => {
-  // const [restaurants, setRestaurants] = useState(null);
-  const {restaurants, setRestaurants } : PartialStore = useStore();
+  
+  const {restaurants, setRestaurants} : PartialStore = useStore();
   
   const slideshowProperties = {
     autoplay: false, // 

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -66,7 +66,7 @@ const LogoutButton = styled(Button)`
 
 
 const ResultsPage = () => {
-  console.log('results page is rendered')
+  //console.log('results page is rendered')
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const {restaurants, setRestaurants} : PartialStore = useStore();
 
@@ -92,8 +92,8 @@ const ResultsPage = () => {
     fetchUserData();
     // fetchRestaurants();
 
-    console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
-    console.log(`RESTAURANTS?`, Array.isArray(restaurants))
+    // console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
+    // console.log(`RESTAURANTS?`, Array.isArray(restaurants))
   }, []);
 
 

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -6,6 +6,10 @@ import MapContainer from '../components/MapContainer';
 import useStore from '../store';
 import { BaseButtonStyle } from '../GlobalStyles';
 import axios from 'axios';
+import axiosInstance from '../axiosInstance';
+import { Restaurant } from '../../types';
+import { PartialStore } from '../../types';
+
 
 const Button = styled.button`${BaseButtonStyle}`;
 
@@ -62,7 +66,9 @@ const LogoutButton = styled(Button)`
 
 
 const ResultsPage = () => {
+  console.log('results page is rendered')
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const {restaurants, setRestaurants} : PartialStore = useStore();
 
   const fetchUserData = async () => {
     try {
@@ -73,8 +79,21 @@ const ResultsPage = () => {
     }
   };
 
+  // const fetchRestaurants = async () => {
+  //   try {
+  //     const restaurantRes = await axiosInstance.get(`/yelp/${useStore.getState().location}`);
+  //     setRestaurants(restaurantRes.data);
+  //   } catch (error) {
+  //     console.error('Error fetching restaurants: ', error);
+  //   }
+  // };
+
   useEffect(() => {
     fetchUserData();
+    // fetchRestaurants();
+
+    console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
+    console.log(`RESTAURANTS?`, Array.isArray(restaurants))
   }, []);
 
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,8 @@ import {
   SetArrivalDate,
   SetEndDate,
   SetLatLong,
-  SetRestaurants
+  SetRestaurants,
+  SetPexelPics
 } from "../types";
 
 interface StoreState {
@@ -40,6 +41,9 @@ interface StoreState {
 
   restaurants: any[],
   setRestaurants: SetRestaurants,
+
+  pexelPics: any[],
+  setPexelPics: SetPexelPics,
 
   initialData: {
     budget:string,
@@ -144,7 +148,15 @@ const useStore = create<StoreState>((set) => ({
   latLong: '',
   setLatLong: (latLong: string): void => set ((state)  => ({
     latLong
-  }))
+  })),
+
+  // pexel pics
+  pexelPics: [],
+  setPexelPics: (pexelPics: any[]): void => set((state) => ({
+    ...state,
+    pexelPics,
+  })),
+
 }));
 
 export default useStore;

--- a/types.ts
+++ b/types.ts
@@ -24,6 +24,9 @@ export interface PartialStore {
     restaurants: any[],
     setRestaurants: SetRestaurants,
 
+    pexelPics: any[],
+    setPexelPics: SetPexelPics,
+
     initialData: {
         budget: string,
         number: number
@@ -89,6 +92,12 @@ export interface Restaurant {
     country: string;
     }
 
+export interface PexelPic {
+    id: string;
+    url: string;
+    alt?: string;
+}
+
 export interface RestaurantCardProps {
     restaurant: Restaurant;
   }
@@ -110,3 +119,5 @@ export type SetEndDate = (date: string) => void;
 export type SetLatLong = (latLong: string) => void;
 
 export type SetRestaurants = (restaurants: any[]) => void; 
+
+export type SetPexelPics = (pexelPics: any[]) => void;


### PR DESCRIPTION
# Overview

## Task

Same as used in the feature branch

- [x] Bug
- [ ] Feature

## Description
- Current bug: GptResponse is successful, however, Itinerary component is not properly rendering the data
- Restaurants & Map component successfully fetching information again and rendering data correctly on the front end
- Yelp Fetch request current commented out
- Restaurants/Map components currently rendering mock data to save API calls
- Added mock data for GptResponse in file MockData2.tsx. 
- Goal is to render this mock data properly in the Itinerary component

## Ticket

## Bug Reproduction Steps

1. Run 'npm run start-all'
2. Proceed to  [http://localhost:3000/results](url)
3. Mock data should be rendered for restaurants
4. Map component has successful network call but not rendering (not important)
5. Itinerary component has "loading" and not properly rendering GptResponse mock data

## Previous Behavior
- Consistent "restaurants.map" react rendering error

## Expected Behavior
- Restaurant/Map component properly working again

## Screenshots & Videos
![Screenshot 2023-09-06 at 8 31 40 PM](https://github.com/Travel-T1me/travel-t1me/assets/112226540/3a2c7946-a9e8-4d12-89ab-73b5a49bd8ab)
