### PR TITLE
Kp824/fe itinerary card

### DIFF
--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -105,7 +105,7 @@ const Itinerary = () => {
         const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
         // save response data to store
         setPexelPics(pexelsResponse.data.photos);
-  
+        console.log(`Pexel List of images after setting:`, pexelPics);
       } catch(error) {
         console.log(`Error fetching pexel pics: ${error}`);
       }
@@ -146,54 +146,55 @@ const Itinerary = () => {
     }
   }
 
+  useEffect(() => {
+    console.log(`In third useEffect. Pexel List of images updated:`, pexelPics);
+  }, [pexelPics]);
+
+  // Returned data from Pexel was an array with an object within
+  // This was previous logic that was mapping over an object and not accessing data properly..
+  // pexelPics.map((pexelPic: PexelPic) => (
+  //   <PexelImg src={pexelPic.url} alt={pexelPic.alt} />
+  // ))
+
   return (
     <ItineraryContainer>
       <TripImagesContainer>
-      {/* <TripImagesContainer>
+      
         <Slide easing="ease" {...slideshowProperties}>
           {pexelPics !== null ? (
-            pexelPics.map((pexelPic: PexelPic) => (
-              <PexelImg src={pexelPic.url} alt={pexelPic.alt} />
-            ))
+            <PexelImg src={pexelPics[0].url} alt={pexelPics[0].alt} />
           ) : (
             <p>Loading images...</p>
           )}
-        </Slide> */}
+        </Slide>
 
-        <div>
-          <h1>Loading Trip Images </h1>
-        </div>
-        
         <br />
         <br />
-
-        <GptResponseContainer>
-          {Object.keys(groupedItinerary).length === 0 ? (
-            <>
-              <h1>Loading your itinerary...</h1>
-              <CircularProgress />
-            </>
-          ) : (
-            <>
-              {Object.keys(groupedItinerary).map((day) => (
-                <div key={day}>
-                  {groupedItinerary[day].map((data, index) => (
-                    <ItineraryCard
-                      key={`${day}-${data.timeOfDay}-${index}`}
-                      day={index === 0 ? day : ''}
-                      timeOfDay={data.timeOfDay}
-                      activities={data.activities}
-                    />
-                  ))}
-                </div>
-              ))}
-            </>
-          )}
-        </GptResponseContainer>
-        
       </TripImagesContainer>
 
-      
+      <GptResponseContainer>
+        {Object.keys(groupedItinerary).length === 0 ? (
+          <>
+            <h1>Loading your itinerary...</h1>
+            <CircularProgress />
+          </>
+        ) : (
+          <>
+            {Object.keys(groupedItinerary).map((day) => (
+              <div key={day}>
+                {groupedItinerary[day].map((data, index) => (
+                  <ItineraryCard
+                    key={`${day}-${data.timeOfDay}-${index}`}
+                    day={index === 0 ? day : ''}
+                    timeOfDay={data.timeOfDay}
+                    activities={data.activities}
+                  />
+                ))}
+              </div>
+            ))}
+          </>
+        )}
+      </GptResponseContainer>
 
     </ItineraryContainer>
   )

--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -36,18 +36,15 @@ const ItineraryContainer = styled.div`
 
 const TripImagesContainer = styled.div`
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   width: 100%;
   position: relative;
 `;
 
 
 const PexelImg = styled.img`
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
-  height: 100%;
+  height: 25vh;
   object-fit: cover;
 `;
 
@@ -57,15 +54,14 @@ const GptResponseContainer = styled.div`
   align-items: center;
   max-width: 100%;
   max-height: 500px;
-  min-width: 300px;
   margin: 1rem;
   padding: 2rem;
   border: 1px solid black;
   border-radius: 20px;
   background-color: whitesmoke;
-  padding: 15px;
   overflow-x: hidden;
   overflow-y: auto;
+  flex: 1;
 `;
 
 // Define interfaces for the expected data structure
@@ -85,9 +81,9 @@ interface GroupedItinerary {
 }
 
 
-
 const Itinerary = () => {
-  const {pexelPics, setPexelPics} : PartialStore = useStore();
+  //const {pexelPics, setPexelPics} : PartialStore = useStore();
+  const pexelPics = useStore((state) => state.pexelPics);
 
   const slideshowProperties = {
     autoplay: true, // 
@@ -98,21 +94,6 @@ const Itinerary = () => {
     canSwipe: true,
   }
 
-  useEffect(() => {
-    //console.log(`Before fetch pexel call`);
-    const fetchPexelPics = async () => {
-      try{
-        const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
-        // save response data to store
-        setPexelPics(pexelsResponse.data.photos);
-        console.log(`Pexel List of images after setting:`, pexelPics);
-      } catch(error) {
-        console.log(`Error fetching pexel pics: ${error}`);
-      }
-    };
-    fetchPexelPics();
-  }, [])
-
   // Adjustment here
   const [parsedResponse, setParsedResponse] = useState<ParsedResponse | null>(null);
 
@@ -122,6 +103,7 @@ const Itinerary = () => {
   // const gptResponse = JSON.stringify(data);
 
   React.useEffect(() => {
+    console.log('Itinerary component re-rendered');
     setParsedResponse(parseGPTResponse(gptResponse));
   }, [gptResponse]);
 
@@ -159,17 +141,12 @@ const Itinerary = () => {
   return (
     <ItineraryContainer>
       <TripImagesContainer>
-      
-        <Slide easing="ease" {...slideshowProperties}>
-          {pexelPics !== null ? (
-            <PexelImg src={pexelPics[0].url} alt={pexelPics[0].alt} />
-          ) : (
-            <p>Loading images...</p>
-          )}
-        </Slide>
-
-        <br />
-        <br />
+        {/* <PexelImg src="https://images.pexels.com/photos/3180136/pexels-photo-3180136.jpeg" alt="Scenic Photo Of Mountains During Dawn " /> */}
+        {pexelPics !== null ? (
+          <PexelImg src={pexelPics[0].src.original} alt={pexelPics[0].alt} />
+        ) : (
+          <p>Loading images...</p>
+        )}
       </TripImagesContainer>
 
       <GptResponseContainer>
@@ -204,4 +181,28 @@ const Itinerary = () => {
 export default Itinerary;
 
 
-//{/* <TripImg src="https://images.pexels.com/photos/460672/pexels-photo-460672.jpeg" alt="London Bridge" /> */}
+/* Moving slide presentation of pexel images down to here */
+{/* <Slide easing="ease" {...slideshowProperties}> */}
+          
+          {/*</Slide> */}
+
+/* Moving data fetching for pexel pics to here 
+// useEffect(() => {
+  //   //console.log(`Before fetch pexel call`);
+  //   const fetchPexelPics = async () => {
+  //     try{
+  //       const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
+  //       // save response data to store
+  //       setPexelPics(pexelsResponse.data.photos);
+  //       console.log(`Pexel List of images after setting:`, pexelPics);
+  //     } catch(error) {
+  //       console.log(`Error fetching pexel pics: ${error}`);
+  //     }
+  //   };
+  //   fetchPexelPics();
+  // }, [])
+
+*/
+
+{/* <TripImg src="https://images.pexels.com/photos/460672/pexels-photo-460672.jpeg" alt="London Bridge" />  */}
+

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -66,24 +66,24 @@ export default function Map(): React.ReactElement {
                     />
 
                     {/* Using Mock Data to render map markers */}
-                    {data.map((internalRestaurant) => (
+                    {/* {data.map((internalRestaurant) => (
                         <Marker
                         key={internalRestaurant.id}
                         position={{ lat: internalRestaurant.latitude, lng: internalRestaurant.longitude }}
                         onClick={() => handleMarkerClick(internalRestaurant)}
                     />
-                    ))}
+                    ))} */}
 
 
                     {/* Need to comment out to use Mock Data to render markers instead
                     {/* Restaurant markers */}
-                    {/* {restaurants.map((internalRestaurant) => (
+                    {restaurants.map((internalRestaurant) => (
                         <Marker
                             key={internalRestaurant.id}
                             position={{ lat: internalRestaurant.latitude, lng: internalRestaurant.longitude }}
                             onClick={() => handleMarkerClick(internalRestaurant)}
                         />
-                    ))} */}
+                    ))}
 
                     {/* InfoWindow to display selected restaurant details */}
                     {selectedRestaurant && (

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -92,6 +92,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
         setGptResponse,
         setResponseId,
         setRestaurants,
+        setPexelPics,
     } : PartialStore = useStore();
     
     // state for user inputs
@@ -151,7 +152,13 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     // RESTURANT DATA - commented out to save calls
                     const restaurantResponse = await axiosInstance.get(`/yelp/${useStore.getState().location}`) as any
                     setRestaurants(restaurantResponse.data.data);
+
+                    // Pexel Image Data 
+                    const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
+                    setPexelPics(pexelsResponse.data.photos);
+
                     console.log(`Inside of case 4 of QuestionCard`, useStore.getState())
+
                     break;
             }
             // reveal the next card by changing the state

--- a/src/components/Restaurants.tsx
+++ b/src/components/Restaurants.tsx
@@ -79,18 +79,18 @@ const Restaurants = () => {
           <Slide easing="ease" {...slideshowProperties}>
 
             {/* Using Mock data here to save API calls */}
-            {data.map((restaurant: Restaurant) => (
+            {/* {data.map((restaurant: Restaurant) => (
               <RestaurantCard key={restaurant.id} restaurant={restaurant} />
-            ))}
+            ))} */}
 
-            {/* Commented out to use MockData instead
+            {/* Commented out to use MockData instead */}
             {restaurants !== null ? (
               restaurants.map((restaurant: Restaurant) => (
                 <RestaurantCard key={restaurant.id} restaurant={restaurant} />
               ))
             ) : (
               <div>Loading restaurants...</div>
-            )} */}
+            )}
 
           </Slide>
         </SlideshowContainer>

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -5,9 +5,7 @@ import Restaurants from '../components/Restaurants';
 import MapContainer from '../components/MapContainer';
 import useStore from '../store';
 import { BaseButtonStyle } from '../GlobalStyles';
-import axios from 'axios';
 import axiosInstance from '../axiosInstance';
-import { Restaurant } from '../../types';
 import { PartialStore } from '../../types';
 
 
@@ -68,32 +66,34 @@ const LogoutButton = styled(Button)`
 const ResultsPage = () => {
   //console.log('results page is rendered')
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const {restaurants, setRestaurants} : PartialStore = useStore();
+  //const {pexelPics, setPexelPics } : PartialStore = useStore();
 
   const fetchUserData = async () => {
     try {
-      const response = await axios.get("http://localhost:4000/isAuthenticated", { withCredentials: true });
+      const response = await axiosInstance.get("http://localhost:4000/isAuthenticated", { withCredentials: true });
       setIsLoggedIn(!!response.data);
     } catch (err) {
       console.error("Error fetching user data: ", err);
     }
   };
 
-  // const fetchRestaurants = async () => {
+  // const fetchPexelPics = async () => {
   //   try {
-  //     const restaurantRes = await axiosInstance.get(`/yelp/${useStore.getState().location}`);
-  //     setRestaurants(restaurantRes.data);
+  //     const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
+  //     // save response data to store
+  //     setPexelPics(pexelsResponse.data.photos);
+  //     console.log(`Pexel list of images after setting: `, pexelPics)
+
   //   } catch (error) {
-  //     console.error('Error fetching restaurants: ', error);
+  //     console.log(`Error fetching pexep pics: ${error}`);
   //   }
   // };
 
-  useEffect(() => {
-    fetchUserData();
-    // fetchRestaurants();
 
-    // console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
-    // console.log(`RESTAURANTS?`, Array.isArray(restaurants))
+  useEffect(() => {
+    console.log('ResultsPage component re-rendered');
+    fetchUserData();
+    // fetchPexelPics();
   }, []);
 
 
@@ -121,3 +121,20 @@ const ResultsPage = () => {
 }
 
 export default ResultsPage;
+
+/* Moving the restaurant fetch request to here since it's currently not being used within this component
+
+  // const fetchRestaurants = async () => {
+  //   try {
+  //     const restaurantRes = await axiosInstance.get(`/yelp/${useStore.getState().location}`);
+  //     setRestaurants(restaurantRes.data);
+  //   } catch (error) {
+  //     console.error('Error fetching restaurants: ', error);
+  //   }
+  // };
+
+  // fetchRestaurants();
+
+    // console.log(`Checking restaurants state: ${JSON.stringify(restaurants)}`);
+    // console.log(`RESTAURANTS?`, Array.isArray(restaurants))
+*/


### PR DESCRIPTION
# Overview

## Task

Same as used in the feature branch

- [x] Bug
- [x] Feature

## Description
Updated Results Page
- Pexel pic API data now properly rendering at the top of the Itinerary component
- Map component also rendering map markers for all restaurant locations

## Ticket
#13, #25, #33

**Trello link**
[https://trello.com/c/aSxvd5rI](url)
[https://trello.com/c/34RRyyDu](url)
[https://trello.com/c/3Jl4sO8E](url)

## Feature Validation / Bug Reproduction Steps

1. Run `npm install`
2. Run `npm run start-all`
3. Sign in using Google OAuth 2.0
4. Complete the travel questionnaire.
5. Verify that upon loading of the final itinerary page, an image renders at the top of the itinerary component, followed by the itinerary data from GPT response.
6. Verify map component is rendering map markers.
7. Verify restaurants component is rendering restaurants from inputted travel destination .

## Previous Behavior
Itinerary component was not rendering any images.

## Expected Behavior
-All the main components should be rendering proper information in regards to the data that was inputted during the questionnaire. 

## Screenshots & Videos
![Screenshot 2023-09-21 at 6 27 02 PM](https://github.com/Travel-T1me/travel-t1me/assets/112226540/3dee640a-079d-4426-8e8d-7020890eda52)
![Screenshot 2023-09-21 at 6 28 42 PM](https://github.com/Travel-T1me/travel-t1me/assets/112226540/4a2c9d47-0cf8-42aa-990c-05c85794ab4c)
![Screenshot 2023-09-21 at 6 28 30 PM](https://github.com/Travel-T1me/travel-t1me/assets/112226540/5f4881d9-d0b7-450f-9a84-182091765367)
![Screenshot 2023-09-21 at 6 27 35 PM](https://github.com/Travel-T1me/travel-t1me/assets/112226540/f8f7fde3-1172-4894-96c9-9f9a34e63a43)

## Known Bugs:
- Clicking on the links within the restaurant component will redirect to a new web address. Need it to open a new window/tab instead.
- Styling needs to be improved to keep styling consistent within all window sizes.