### PR TITLE
Kp824/questionnaire

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: "http://localhost:4000",
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -51,7 +51,9 @@ describe('Landing Page', () => {
     cy.wait(500);
     cy.contains('Submit').scrollIntoView();
 
-    cy.get('input[type="date"]').eq(1).type('2023-10-11');
+    // Question: Why do we need the eq(1) here? 
+    //cy.get('input[type="date"]').eq(1).type('2023-10-11');
+    cy.get('input[type="date"]').type('2023-10-11');
     cy.contains('Submit').click()
 
     cy.wait(500);

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -14,11 +14,11 @@
 
 describe('Landing Page', () => {
   it('should visit the landing page and fill out the questionnaire', function() {
-    cy.intercept('GET', 'http://localhost:4000/api/yelp/*', {
+    cy.intercept('GET', 'http://localhost:4000/api/yelp/Los%20Angeles,%20CA,%20USA', {
       fixture: 'losangeles-yelp.json'
     }).as('getYelp');
     
-    cy.visit('/');
+    cy.visit('http://localhost:3000/');
     cy.contains('Get ready to plan your next adventure');
     cy.contains('Get Started').click();
     cy.url().should('eq', 'http://localhost:3000/questionnaire');
@@ -48,7 +48,9 @@ describe('Landing Page', () => {
     cy.contains('Submit').scrollIntoView();
 
     cy.get('input[type="date"]').eq(1).type('2023-10-11');
-    // cy.contains('Submit').click()
-    // cy.wait('@getYelp');
+    cy.contains('Submit').click()
+
+    cy.wait(6000);
+    cy.wait('@getYelp', { timeout: 10000 });
   });
 });

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -10,13 +10,17 @@
 //   it('Does not do much!', () => {
 //     expect(true).to.equal(false)
 //   })
-// })
+//})
+
+//http://localhost:4000/api/yelp/Los%20Angeles,%20CA,%20USA
+// {
+//   fixture: 'losangeles-yelp.json'
+// }
+//http://localhost:4000/api/yelp/
 
 describe('Landing Page', () => {
   it('should visit the landing page and fill out the questionnaire', function() {
-    cy.intercept('GET', 'http://localhost:4000/api/yelp/Los%20Angeles,%20CA,%20USA', {
-      fixture: 'losangeles-yelp.json'
-    }).as('getYelp');
+    cy.intercept('GET', '*').as('getYelp');
     
     cy.visit('http://localhost:3000/');
     cy.contains('Get ready to plan your next adventure');
@@ -50,7 +54,7 @@ describe('Landing Page', () => {
     cy.get('input[type="date"]').eq(1).type('2023-10-11');
     cy.contains('Submit').click()
 
-    cy.wait(6000);
-    cy.wait('@getYelp', { timeout: 10000 });
+    cy.wait(500);
+    cy.wait('@getYelp').its('response.statusCode').should('eq', 200);
   });
 });

--- a/src/components/AutoComplete.tsx
+++ b/src/components/AutoComplete.tsx
@@ -39,6 +39,6 @@ export default function AutoComplete(): React.ReactElement {
 
 
   return (
-    <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0' }} ref={ref} placeholder='Enter location' />
+    <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0', backgroundColor: 'hsl(180, 47%, 80%)', }} ref={ref} placeholder='Enter location' />
   );
 }

--- a/src/components/AutoComplete.tsx
+++ b/src/components/AutoComplete.tsx
@@ -39,6 +39,21 @@ export default function AutoComplete(): React.ReactElement {
 
 
   return (
-    <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0', backgroundColor: 'hsl(180, 47%, 80%)', }} ref={ref} placeholder='Enter location' />
+    <input 
+      style={{
+        width: '75%', 
+        height: '40px', 
+        border: 'solid',
+        borderColor: 'darkcyan',
+        borderRadius: '20px', 
+        margin:'50px 0', 
+        fontSize: '20px', 
+        textAlign: 'center', 
+        padding: '0 10px 0 0', 
+        backgroundColor: 'rgb(242, 242, 242)', 
+      }} 
+      ref={ref} 
+      placeholder='Enter location' 
+    />
   );
 }

--- a/src/components/Itinerary.tsx
+++ b/src/components/Itinerary.tsx
@@ -142,7 +142,7 @@ const Itinerary = () => {
     <ItineraryContainer>
       <TripImagesContainer>
         {/* <PexelImg src="https://images.pexels.com/photos/3180136/pexels-photo-3180136.jpeg" alt="Scenic Photo Of Mountains During Dawn " /> */}
-        {pexelPics !== null ? (
+        {pexelPics && pexelPics.length > 0 ? (
           <PexelImg src={pexelPics[0].src.original} alt={pexelPics[0].alt} />
         ) : (
           <p>Loading images...</p>

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -9,13 +9,17 @@ import { PartialStore } from '../../types';
 import axiosInstance from '../axiosInstance';
 import AutoComplete from "./AutoComplete";
 
+interface CardProps {
+    $show?: boolean;
+}
+
 
 const Button = styled.button`${BaseButtonStyle}`;
 
 
-const Card = styled.div`
-    border:solid;
-    border-color: darkcyan;
+const Card = styled.div<CardProps>`
+    border: 2px solid;
+    border-color: black;
     border-radius:25px;
     background-color: ivory;
     width:650px;
@@ -24,6 +28,8 @@ const Card = styled.div`
     margin:100px;
     text-align: center;
     justify-content: center;
+    // opacity: ${props => (props.$show ? 1 : 0)};
+    transition: opacity 0.5s ease-in-out;
 `
 
 const Buttons = styled.section`
@@ -103,6 +109,11 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
         if (!boo && el !== 0){
             newState[el] = false;
             setQuestionStates(newState);
+
+            // Update to the prev question index
+            if (currentQuestionIndex < questionStates.length - 1) {
+                setCurrentQuestionIndex(currentQuestionIndex - 1);
+            }
         } 
         else if (boo){
             switch (index) {
@@ -148,7 +159,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
             setQuestionStates(newState);
             console.log(`State after setQuestionStates: ${newState}`);
 
-            // Upddate the current question index
+            // Update to the next question index
             if (currentQuestionIndex < questionStates.length - 1) {
                 setCurrentQuestionIndex(currentQuestionIndex + 1);
             }
@@ -202,7 +213,19 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
 
     if (type === 'select'){
         inputField = 
-        <select name='budget' style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0' }} onChange={handleSelectChange}>
+        <select name='budget' 
+            style={{    
+                width: '75%', 
+                height: '40px', 
+                border: 'solid', 
+                borderRadius: '20px', 
+                margin:'50px 0', 
+                fontSize: '20px', 
+                textAlign: 'center', 
+                padding: '0 10px 0 0',
+                backgroundColor: 'hsl(180, 47%, 80%)',
+                }} 
+            onChange={handleSelectChange}>
             <option value='none' selected disabled hidden>Select a budget</option>
             <option value='$'>1</option>
             <option value='$$'>2</option>
@@ -212,7 +235,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
     } else if (type === 'location'){
         inputField = <AutoComplete />
     } else {
-        inputField = <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0' }} type={type} onChange={handleChange}/>
+        inputField = <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0', backgroundColor: 'hsl(180, 47%, 80%)', }} type={type} onChange={handleChange}/>
     }
 
     console.log(`Check check....need to check questionState of QuestionCard: ${questionStates}`)

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -149,16 +149,19 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                 case 4:
                     setEndDate(answer);
 
-                    // RESTURANT DATA - commented out to save calls
-                    const restaurantResponse = await axiosInstance.get(`/yelp/${useStore.getState().location}`) as any
-                    setRestaurants(restaurantResponse.data.data);
+                    try {
+                        // RESTURANT DATA - commented out to save calls
+                        const restaurantResponse = await axiosInstance.get(`/yelp/${useStore.getState().location}`) as any
+                        setRestaurants(restaurantResponse.data.data);
 
-                    // Pexel Image Data 
-                    const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
-                    setPexelPics(pexelsResponse.data.photos);
+                        // Pexel Image Data 
+                        const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
+                        setPexelPics(pexelsResponse.data.photos);
 
-                    console.log(`Inside of case 4 of QuestionCard`, useStore.getState())
-
+                        console.log(`Inside of case 4 of QuestionCard`, useStore.getState())
+                    } catch(error) {
+                        console.error(`An error occurred during Axios requests in case 4, QuestionCard component.`, error);
+                    }
                     break;
             }
             // reveal the next card by changing the state

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -28,8 +28,12 @@ const Card = styled.div<CardProps>`
     margin:100px;
     text-align: center;
     justify-content: center;
+    // These transitions are currently not working
     opacity: ${props => (props.$show ? 1 : 0)};
-    transition: color 1s, opacity 1s ease-in-out;
+    transition: opacity 0.5s ease;
+    // transform: scaleY(${props => (props.$show ? 1 : 0)});
+    // transform-origin: top;
+    // transition: transform 1s ease-in-out;
 `
 
 const Buttons = styled.section`
@@ -109,9 +113,22 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
         if (!boo && el !== 0){
             newState[el] = false;
             setQuestionStates(newState);
+
+            // Set the previous card to true to show previous card
+            newState[el - 1] = true;
+            setQuestionStates(newState);
+
+            // transition to the previous card
             setCurrentQuestionIndex(currentQuestionIndex - 1);
+            console.log(`Checking currentQuestionIndex, back button: ${currentQuestionIndex}`);
         } 
         else if (boo){
+            // Transition the current card to false if it's not the last one
+            if (el < questionStates.length - 1) {
+                newState[el] = false;
+                setQuestionStates(newState);
+            }
+
             switch (index) {
                 case 0:
                     setNumberOfTravellers(answer);
@@ -123,11 +140,11 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
                     
                     break;
                 case 2:
-                    console.log(`Inside case 2 of QuestionCard`,useStore.getState())
+                    //console.log(`Inside case 2 of QuestionCard`,useStore.getState())
                     break;
                 case 3:
                     setArrivalDate(answer);
-                    console.log(`Inside of case 3 of QuestionCard`,useStore.getState())
+                    //console.log(`Inside of case 3 of QuestionCard`,useStore.getState())
                     break;
                 case 4:
                     setEndDate(answer);
@@ -141,24 +158,30 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
                         const pexelsResponse = await axiosInstance.get(`/pexels?query=${useStore.getState().location}`);
                         setPexelPics(pexelsResponse.data.photos);
 
-                        console.log(`Inside of case 4 of QuestionCard`, useStore.getState())
+                        //console.log(`Inside of case 4 of QuestionCard`, useStore.getState())
                     } catch(error) {
                         console.error(`An error occurred during Axios requests in case 4, QuestionCard component.`, error);
                     }
                     break;
             }
             // reveal the next card by changing the state
-            console.log(`Check questionStates of question: ${question}`)
-            console.log(`Updated state for QuestionCard, newState: ${newState}`);
-            console.log(`Transitioning to next card.`);
-            newState[el + 1] = true;
-            setQuestionStates(newState);
-            console.log(`State after setQuestionStates: ${newState}`);
+            //console.log(`Check questionStates of question: ${question}`)
+            //console.log(`Updated state for QuestionCard, newState: ${newState}`);
+            //console.log(`Transitioning to next card.`);
+
+            if (el < questionStates.length - 1) {
+                // transition to next card
+                newState[el + 1] = true;
+                setQuestionStates(newState);
+                //console.log(`State after setQuestionStates: ${newState}`);
+            }
+            
 
             // Update to the next question index
             if (currentQuestionIndex < questionStates.length - 1) {
                 setCurrentQuestionIndex(currentQuestionIndex + 1);
             }
+            console.log(`Checking currentQuestionIndex, forward button: ${currentQuestionIndex}`);
             
         }
     })
@@ -166,7 +189,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
     const sendToGpt = async (): Promise<void> => {
         setAdditionalNotes(answer)
 
-        console.log(`Checking if restaurants is an array within sendToGpt: ${useStore.getState()}`);
+        //console.log(`Checking if restaurants is an array within sendToGpt: ${useStore.getState()}`);
 
         const restaurants = useStore.getState().restaurants.map(restaurant => {
             return {
@@ -199,10 +222,10 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
             }};
         const gptResponse = await gptRes()
 
-        console.log(`gptResponse`, gptResponse.data.response)
+        //console.log(`gptResponse`, gptResponse.data.response)
         setGptResponse(gptResponse.data.response);
         setResponseId(gptResponse.data.id)
-        console.log('final state', useStore.getState())
+        //console.log('final state', useStore.getState())
     }
 
     let inputField;
@@ -250,6 +273,9 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
     }
 
     console.log(`Check check....need to check questionState of QuestionCard: ${questionStates}`)
+    //console.log(`Checking currentQuestionIndex, back button, above return statement: ${currentQuestionIndex}`);
+    //console.log(`Checking currentQuestionIndex, forward button, above return statement: ${currentQuestionIndex}`);
+
     return (
         <>
             <Card $show={questionStates[currentQuestionIndex]}>
@@ -258,20 +284,20 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
                 <br />
                 <Buttons>
                     {
-                    el === questionStates.length - 1 && <Link to={`/results`}><SubmitButton onClick={() => sendToGpt()}>
-                        Get your itinerary
-                    </SubmitButton></Link>
-                    } 
+                    (el !== 0 || el === questionStates.length - 1) && !questionStates[el + 1] && <BackButton onClick={() => handleClick(false, el)}>
+                        Go Back
+                    </BackButton>
+                    }
                     {       
                     !questionStates[el+1] && el < questionStates.length - 1 && <SubmitButton onClick={() => handleClick(true, el)}>
                         Submit
                     </SubmitButton>
                     }
                     {
-                    (el !== 0 || el === questionStates.length - 1) && !questionStates[el + 1] && <BackButton onClick={() => handleClick(false, el)}>
-                        Go Back
-                    </BackButton>
-                    }
+                    el === questionStates.length - 1 && <Link to={`/results`}><SubmitButton onClick={() => sendToGpt()}>
+                        Get your itinerary
+                    </SubmitButton></Link>
+                    } 
                 </Buttons>
             </Card>
         </>

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -19,7 +19,7 @@ const Button = styled.button`${BaseButtonStyle}`;
 
 const Card = styled.div<CardProps>`
     border: 2px solid;
-    border-color: black;
+    border-color: darkcyan;
     border-radius:25px;
     background-color: ivory;
     width:650px;
@@ -28,8 +28,8 @@ const Card = styled.div<CardProps>`
     margin:100px;
     text-align: center;
     justify-content: center;
-    // opacity: ${props => (props.$show ? 1 : 0)};
-    transition: opacity 0.5s ease-in-out;
+    opacity: ${props => (props.$show ? 1 : 0)};
+    transition: color 1s, opacity 1s ease-in-out;
 `
 
 const Buttons = styled.section`
@@ -109,11 +109,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
         if (!boo && el !== 0){
             newState[el] = false;
             setQuestionStates(newState);
-
-            // Update to the prev question index
-            if (currentQuestionIndex < questionStates.length - 1) {
-                setCurrentQuestionIndex(currentQuestionIndex - 1);
-            }
+            setCurrentQuestionIndex(currentQuestionIndex - 1);
         } 
         else if (boo){
             switch (index) {
@@ -213,18 +209,19 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
 
     if (type === 'select'){
         inputField = 
-        <select name='budget' 
-            style={{    
-                width: '75%', 
-                height: '40px', 
-                border: 'solid', 
-                borderRadius: '20px', 
-                margin:'50px 0', 
-                fontSize: '20px', 
-                textAlign: 'center', 
-                padding: '0 10px 0 0',
-                backgroundColor: 'hsl(180, 47%, 80%)',
-                }} 
+            <select name='budget' 
+                style={{    
+                    width: '75%', 
+                    height: '40px', 
+                    border: 'solid',
+                    borderColor: 'darkcyan', 
+                    borderRadius: '20px', 
+                    margin:'50px 0', 
+                    fontSize: '20px', 
+                    textAlign: 'center', 
+                    padding: '0 10px 0 0',
+                    backgroundColor: 'rgb(242, 242, 242)',
+                    }} 
             onChange={handleSelectChange}>
             <option value='none' selected disabled hidden>Select a budget</option>
             <option value='$'>1</option>
@@ -235,44 +232,54 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates, se
     } else if (type === 'location'){
         inputField = <AutoComplete />
     } else {
-        inputField = <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0', backgroundColor: 'hsl(180, 47%, 80%)', }} type={type} onChange={handleChange}/>
+        inputField = 
+            <input 
+                style={{
+                    width: '75%', 
+                    height: '40px', 
+                    border: 'solid',
+                    borderColor: 'darkcyan', 
+                    borderRadius: '20px', 
+                    margin:'50px 0', 
+                    fontSize: '20px', 
+                    textAlign: 'center', 
+                    padding: '0 10px 0 0', 
+                    backgroundColor: 'rgb(242, 242, 242)', 
+                }} type={type} 
+            onChange={handleChange}/>
     }
 
     console.log(`Check check....need to check questionState of QuestionCard: ${questionStates}`)
     return (
         <>
-            {/* <CardContainer> */}
-                <Card>
-                    <Question>{question}</Question>
-                    <InputField>{inputField}</InputField>
-                    <br />
-                    <Buttons>
-                        {
-                        el === questionStates.length - 1 && <Link to={`/results`}><SubmitButton onClick={() => sendToGpt()}>
-                            Get your itinerary
-                        </SubmitButton></Link>
-                        } 
-                        {       
-                        !questionStates[el+1] && el < questionStates.length - 1 && <SubmitButton onClick={() => handleClick(true, el)}>
-                            Submit
-                        </SubmitButton>
-                        }
-                        {
-                        el !== 0 && !questionStates[el + 1] && <BackButton onClick={() => handleClick(false, el)}>
-                            Go Back
-                        </BackButton>
-                        }
-
-                    </Buttons>
-                </Card>
-            {/* </CardContainer> */}
+            <Card $show={questionStates[currentQuestionIndex]}>
+                <Question>{question}</Question>
+                <InputField>{inputField}</InputField>
+                <br />
+                <Buttons>
+                    {
+                    el === questionStates.length - 1 && <Link to={`/results`}><SubmitButton onClick={() => sendToGpt()}>
+                        Get your itinerary
+                    </SubmitButton></Link>
+                    } 
+                    {       
+                    !questionStates[el+1] && el < questionStates.length - 1 && <SubmitButton onClick={() => handleClick(true, el)}>
+                        Submit
+                    </SubmitButton>
+                    }
+                    {
+                    (el !== 0 || el === questionStates.length - 1) && !questionStates[el + 1] && <BackButton onClick={() => handleClick(false, el)}>
+                        Go Back
+                    </BackButton>
+                    }
+                </Buttons>
+            </Card>
         </>
-        
         
     )
 }
 
-export default QuestionCard
+export default QuestionCard;
 
 
 // This wrapper component commented out has no change in the display. Commenting out for now, ready for deletion.

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -12,20 +12,6 @@ import AutoComplete from "./AutoComplete";
 
 const Button = styled.button`${BaseButtonStyle}`;
 
-// This wrapper component commented out has no change in the display. Commenting out for now, ready for deletion.
-// const Wrapper = styled.div`
-//     display:flex;
-//     justify-content:center;
-//     align-items:center;
-//     height: 100vh;
-// `
-
-// const CardContainer = styled.div`
-//     display: flex;
-//     height: 100vh;
-//     align-items: center;
-//     justify-content: center;
-// `
 
 const Card = styled.div`
     border:solid;
@@ -81,7 +67,7 @@ const InputField = styled.section`
     border: black;
 `
 
-const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: QuestionCardType) => {
+const QuestionCard = ({question, type, el, setQuestionStates, questionStates, setCurrentQuestionIndex, currentQuestionIndex}: QuestionCardType) => {
 
     // store and reducers
     const {
@@ -125,8 +111,8 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     break;
                 case 1:
                     setYelpBudget(answer);
-                    const usersYelpBudget = useStore.getState().yelpBudget
-                    const travellers = Number(useStore.getState().numOfTravellers)
+                    //const usersYelpBudget = useStore.getState().yelpBudget
+                    //const travellers = Number(useStore.getState().numOfTravellers)
                     
                     break;
                 case 2:
@@ -155,14 +141,18 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     break;
             }
             // reveal the next card by changing the state
+            console.log(`Check questionStates of question: ${question}`)
+            console.log(`Updated state for QuestionCard, newState: ${newState}`);
+            console.log(`Transitioning to next card.`);
             newState[el + 1] = true;
             setQuestionStates(newState);
+            console.log(`State after setQuestionStates: ${newState}`);
 
-            // scroll to the new card (TODO)
-                // THIS IS WHERE I LEFT OFF
-                // ref.current.scrollIntoView({
-                //     behavior: 'smooth'
-                // })
+            // Upddate the current question index
+            if (currentQuestionIndex < questionStates.length - 1) {
+                setCurrentQuestionIndex(currentQuestionIndex + 1);
+            }
+            
         }
     })
 
@@ -225,6 +215,7 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
         inputField = <input style={{width: '75%', height: '40px', border: 'solid', borderRadius: '20px', margin:'50px 0', fontSize: '20px', textAlign: 'center', padding: '0 10px 0 0' }} type={type} onChange={handleChange}/>
     }
 
+    console.log(`Check check....need to check questionState of QuestionCard: ${questionStates}`)
     return (
         <>
             {/* <CardContainer> */}
@@ -259,3 +250,28 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
 }
 
 export default QuestionCard
+
+
+// This wrapper component commented out has no change in the display. Commenting out for now, ready for deletion.
+// const Wrapper = styled.div`
+//     display:flex;
+//     justify-content:center;
+//     align-items:center;
+//     height: 100vh;
+// `
+
+// const CardContainer = styled.div`
+//     display: flex;
+//     height: 100vh;
+//     align-items: center;
+//     justify-content: center;
+// `
+
+
+
+// took out of the handleClick function right before the sendToGpt function:
+// scroll to the new card (TODO)
+                // THIS IS WHERE I LEFT OFF
+                // ref.current.scrollIntoView({
+                //     behavior: 'smooth'
+                // })

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -12,19 +12,20 @@ import AutoComplete from "./AutoComplete";
 
 const Button = styled.button`${BaseButtonStyle}`;
 
-const Wrapper = styled.div`
-    display:flex;
-    justify-content:center;
-    align-items:center;
-    height: 100vh;
-`
+// This wrapper component commented out has no change in the display. Commenting out for now, ready for deletion.
+// const Wrapper = styled.div`
+//     display:flex;
+//     justify-content:center;
+//     align-items:center;
+//     height: 100vh;
+// `
 
-const CardContainer = styled.div`
-    display: flex;
-    height: 100vh;
-    align-items: center;
-    justify-content: center;
-`
+// const CardContainer = styled.div`
+//     display: flex;
+//     height: 100vh;
+//     align-items: center;
+//     justify-content: center;
+// `
 
 const Card = styled.div`
     border:solid;
@@ -127,17 +128,6 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                     const usersYelpBudget = useStore.getState().yelpBudget
                     const travellers = Number(useStore.getState().numOfTravellers)
                     
-                    //don't need to set this or mongoId anymore 
-                    // setInitialData(usersYelpBudget, travellers);
-                    // const initialRes = async () => {
-                    //     try {
-                    //         const data = await axiosInstance.post('/initial', initialData);
-                    //         return data
-                    //     } catch (err) {
-                    //         console.error('Err:', err)
-                    //     }}
-                    // const initialResponse = await initialRes()
-                    // setMongoID(initialResponse.data);
                     break;
                 case 2:
                     console.log(`Inside case 2 of QuestionCard`,useStore.getState())
@@ -236,8 +226,8 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
     }
 
     return (
-        <Wrapper>
-            <CardContainer>
+        <>
+            {/* <CardContainer> */}
                 <Card>
                     <Question>{question}</Question>
                     <InputField>{inputField}</InputField>
@@ -258,12 +248,13 @@ const QuestionCard = ({question, type, el, setQuestionStates, questionStates}: Q
                             Go Back
                         </BackButton>
                         }
- 
+
                     </Buttons>
                 </Card>
-            </CardContainer>
+            {/* </CardContainer> */}
+        </>
         
-        </Wrapper>
+        
     )
 }
 

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -22,29 +22,6 @@ const Homepage = () => {
   }
 
 
-  // React.useEffect(() => {
-  //   const fetch = async () => {
-  //     try {
-  //       console.log('hi');
-  //       const initialRes = await axiosInstance.post('/initial', initialSend); //after user inputs num travellers
-  //       const mongoID = initialRes.data;
-  //       const weatherRes = await axiosInstance.post(`/weather/${mongoID}`, sendWeather); //after user inputs destination
-  //       const restaurantRes = await axiosInstance.post(`/yelp/${mongoID}`) // probably be sent at the same time
-  //       const notesRes = await axiosInstance.post(`/notes/${mongoID}`, {
-  //         notes: `We are celebrating the birthday of a friend turning 30 on Sep 3, 2023.`
-  //       }) //after notes
-  //       const gptRes = await axiosInstance.post(`/llm/${mongoID}`, {docID: mongoID}); // final submit
-  //       console.log(gptRes.data);
-
-  //     } catch(err) {
-  //       console.error('Err:', err);
-  //     }
-  //   }
-
-  //   fetch();
-  // }, [])
-
-
   const isNavbarVisible = false;
 
   useEffect(() => {
@@ -70,3 +47,26 @@ const Homepage = () => {
 
 //{console.log("DATADAtA", data)}
 export default Homepage;
+
+
+  // React.useEffect(() => {
+  //   const fetch = async () => {
+  //     try {
+  //       console.log('hi');
+  //       const initialRes = await axiosInstance.post('/initial', initialSend); //after user inputs num travellers
+  //       const mongoID = initialRes.data;
+  //       const weatherRes = await axiosInstance.post(`/weather/${mongoID}`, sendWeather); //after user inputs destination
+  //       const restaurantRes = await axiosInstance.post(`/yelp/${mongoID}`) // probably be sent at the same time
+  //       const notesRes = await axiosInstance.post(`/notes/${mongoID}`, {
+  //         notes: `We are celebrating the birthday of a friend turning 30 on Sep 3, 2023.`
+  //       }) //after notes
+  //       const gptRes = await axiosInstance.post(`/llm/${mongoID}`, {docID: mongoID}); // final submit
+  //       console.log(gptRes.data);
+
+  //     } catch(err) {
+  //       console.error('Err:', err);
+  //     }
+  //   }
+
+  //   fetch();
+  // }, [])

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -12,13 +12,13 @@ interface WrapperProps {
 
 
 // This component controls the visibility of the question card:
-// const Wrapper = styled.div<WrapperProps>`
-//   background-color: transparent;
-//   opacity: ${props => (props.$show ? 1 : 0)};
-//   transition: color 1s, opacity 1s;
-//   color: ${props => (props.$focus ? "black": "transparent")};
-//   text-shadow: ${props => (props.$focus ? "0 0 0px" : "0 0 5px rgba(0,0,0,0.5)")};
-// `;
+const Wrapper = styled.div<WrapperProps>`
+  background-color: transparent;
+  opacity: ${props => (props.$show ? 1 : 0)};
+  transition: color 1s, opacity 1s;
+  color: ${props => (props.$focus ? "black": "transparent")};
+  text-shadow: ${props => (props.$focus ? "0 0 0px" : "0 0 5px rgba(0,0,0,0.5)")};
+`;
 
 
 const Questionnaire = () => {
@@ -51,49 +51,52 @@ const Questionnaire = () => {
   ];
 
   // Initialize questionStates so that only the first QuestionCard is initially displayed
-  const initialQuestionStates = questionList.map((_, index) => index === 0);
+  //const initialQuestionStates = questionList.map((_, index) => index === 0);
 
-  // dates come back as string in yyyy-mm-dd format
+  // Hook to verify when question cards have been answered
   const [questionStates, setQuestionStates] = useState([true, false, false, false, false, false])
 
+  const currentQuestionIndex = questionStates.findIndex((state) => state);
 
-  // useEffect(() => {
-  //   window.scroll(0, 0);
-  // }, []);
+  const currentQuestion = questionList[currentQuestionIndex];
 
-  // const refsArray = questionList.map(() => useRef(0));
 
-  const questionComponents = questionList.map((obj, index) => (
+  
+  // Check why this property was needed within NavBar component: key={`${index}` + 'NavBar'}
+
+  const currentQuestionsComponent = (
     <>
-      <NavBar key={`${index}` + 'NavBar'} visible={true}/>
+      <NavBar visible={true}/>
 
       <div style={{ display: 'flex', justifyContent: 'center' }}>
 
-        {/* <Wrapper key={`${index}` + 'Wrapper'} $show={questionStates[index]} $focus={!questionStates[index+1] || index === questionStates.length - 1}> */}
+        <Wrapper 
+          key={`${currentQuestionIndex}` + 'Wrapper'} 
+          $show={questionStates[currentQuestionIndex]} 
+          $focus={!questionStates[currentQuestionIndex + 1] || currentQuestionIndex === questionStates.length - 1}
+        >
           
           <QuestionCard
-          // ref={refsArray[index]}
-          key={index} 
-          el={index} 
-          question={obj.question} 
-          type={obj.type} 
-          setQuestionStates={setQuestionStates}
-          questionStates={questionStates}
+            key={currentQuestionIndex} 
+            el={currentQuestionIndex} 
+            question={currentQuestion.question} 
+            type={currentQuestion.type} 
+            setQuestionStates={setQuestionStates}
+            questionStates={questionStates}
           />
           
-        {/* </Wrapper> */}
+        </Wrapper>
 
       </div>
     </>
 
-  ))
-
+  );
 
   return (
     <>
-      {questionComponents}
+      {currentQuestionsComponent}
     </>
-  )
+  );
 }
 
 

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -10,40 +10,15 @@ interface WrapperProps {
   $focus?: boolean;
 }
 
-const CardShadow = styled.div`
-  display: inline-block;
-  position: relative;
-  height: 80%;
 
-  &::before {
-    content: "";
-    position: absolute;
-    z-index: -1;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: linear-gradient(
-      to right,
-      rgb(102, 255, 255),
-      rgb(0, 153, 153)
-    );
-    transform: translateY(120px) scale(0.75);
-    filter: blur(16px);
-  }
-  transition: transform 0.2s ease-in-out;
-  &:hover {
-    transform: translateY(-5px) scale(1.02);
-  }
-`;
-
-const Wrapper = styled.div<WrapperProps>`
-  background-color: transparent;
-  opacity: ${props => (props.$show ? 1 : 0)};
-  transition: color 1s, opacity 1s;
-  color: ${props => (props.$focus ? "black": "transparent")};
-  text-shadow: ${props => (props.$focus ? "0 0 0px" : "0 0 5px rgba(0,0,0,0.5)")};
-`;
+// This component controls the visibility of the question card:
+// const Wrapper = styled.div<WrapperProps>`
+//   background-color: transparent;
+//   opacity: ${props => (props.$show ? 1 : 0)};
+//   transition: color 1s, opacity 1s;
+//   color: ${props => (props.$focus ? "black": "transparent")};
+//   text-shadow: ${props => (props.$focus ? "0 0 0px" : "0 0 5px rgba(0,0,0,0.5)")};
+// `;
 
 
 const Questionnaire = () => {
@@ -82,9 +57,9 @@ const Questionnaire = () => {
   const [questionStates, setQuestionStates] = useState([true, false, false, false, false, false])
 
 
-  useEffect(() => {
-    window.scroll(0, 0);
-  }, []);
+  // useEffect(() => {
+  //   window.scroll(0, 0);
+  // }, []);
 
   // const refsArray = questionList.map(() => useRef(0));
 
@@ -94,24 +69,22 @@ const Questionnaire = () => {
 
       <div style={{ display: 'flex', justifyContent: 'center' }}>
 
-        <Wrapper key={`${index}` + 'Wrapper'} $show={questionStates[index]} $focus={!questionStates[index+1] || index === questionStates.length - 1}>
-          <CardShadow>
-            <QuestionCard
-            // ref={refsArray[index]}
-            key={index} 
-            el={index} 
-            question={obj.question} 
-            type={obj.type} 
-            setQuestionStates={setQuestionStates}
-            questionStates={questionStates}
-            />
-          </CardShadow>
-        </Wrapper>
+        {/* <Wrapper key={`${index}` + 'Wrapper'} $show={questionStates[index]} $focus={!questionStates[index+1] || index === questionStates.length - 1}> */}
+          
+          <QuestionCard
+          // ref={refsArray[index]}
+          key={index} 
+          el={index} 
+          question={obj.question} 
+          type={obj.type} 
+          setQuestionStates={setQuestionStates}
+          questionStates={questionStates}
+          />
+          
+        {/* </Wrapper> */}
 
       </div>
     </>
-
-
 
   ))
 
@@ -125,3 +98,34 @@ const Questionnaire = () => {
 
 
 export default Questionnaire;
+
+
+
+
+// Commenting out card shadow for now since we won't need it. Needing to test other functionality first
+// const CardShadow = styled.div`
+//   display: inline-block;
+//   position: relative;
+//   height: 80%;
+
+//   &::before {
+//     content: "";
+//     position: absolute;
+//     z-index: -1;
+//     top: 0;
+//     bottom: 0;
+//     left: 0;
+//     right: 0;
+//     background: linear-gradient(
+//       to right,
+//       rgb(102, 255, 255),
+//       rgb(0, 153, 153)
+//     );
+//     transform: translateY(120px) scale(0.75);
+//     filter: blur(16px);
+//   }
+//   transition: transform 0.2s ease-in-out;
+//   &:hover {
+//     transform: translateY(-5px) scale(1.02);
+//   }
+// `;

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -60,17 +60,31 @@ const Questionnaire = () => {
   return (
     <>
       <QuestionnairePage>
-        {/* {currentQuestionsComponent} */}
+        {/* This block of code will currently render two cards a time...Need to sync el prop with "currentQuestionIndex" or merge with key somehow. */}
+        {/* {questionList.map((currentQuestion, index) => (
+          <QuestionCard
+          key={index} 
+          el={index} 
+          question={currentQuestion.question} 
+          type={currentQuestion.type} 
+          setQuestionStates={setQuestionStates}
+          questionStates={questionStates}
+          setCurrentQuestionIndex={setCurrentQuestionIndex}
+          currentQuestionIndex={currentQuestionIndex}
+        />
+        ))} */}
+
         <QuestionCard
-            key={currentQuestionIndex} 
-            el={currentQuestionIndex} 
-            question={currentQuestion.question} 
-            type={currentQuestion.type} 
-            setQuestionStates={setQuestionStates}
-            questionStates={questionStates}
-            setCurrentQuestionIndex={setCurrentQuestionIndex}
-            currentQuestionIndex={currentQuestionIndex}
-          />
+          key={currentQuestionIndex} 
+          el={currentQuestionIndex} 
+          question={currentQuestion.question} 
+          type={currentQuestion.type} 
+          setQuestionStates={setQuestionStates}
+          questionStates={questionStates}
+          setCurrentQuestionIndex={setCurrentQuestionIndex}
+          currentQuestionIndex={currentQuestionIndex}
+        />
+        
       </QuestionnairePage>
     </>
   );

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import QuestionCard from '../components/QuestionCard';
 import { QuestionCardType } from '../../types'
 import { styled } from 'styled-components'
-import NavBar from '../components/Navbar'
+import Navbar from '../components/Navbar'
 import axiosInstance from '../axiosInstance'
 
 interface WrapperProps {
@@ -50,13 +50,15 @@ const Questionnaire = () => {
     }
   ];
 
+  // const isNavbarVisible = false;
+
   // Initialize questionStates so that only the first QuestionCard is initially displayed
   //const initialQuestionStates = questionList.map((_, index) => index === 0);
 
   // Hook to verify when question cards have been answered
   const [questionStates, setQuestionStates] = useState([true, false, false, false, false, false])
 
-  const currentQuestionIndex = questionStates.findIndex((state) => state);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0); 
 
   const currentQuestion = questionList[currentQuestionIndex];
 
@@ -66,7 +68,9 @@ const Questionnaire = () => {
 
   const currentQuestionsComponent = (
     <>
-      <NavBar visible={true}/>
+      {/* <NavBar key={`${currentQuestionIndex}` + 'NavBar'} visible={true}/> */}
+      {/* <Navbar visible={isNavbarVisible}/> */}
+      
 
       <div style={{ display: 'flex', justifyContent: 'center' }}>
 
@@ -83,6 +87,8 @@ const Questionnaire = () => {
             type={currentQuestion.type} 
             setQuestionStates={setQuestionStates}
             questionStates={questionStates}
+            setCurrentQuestionIndex={setCurrentQuestionIndex}
+            currentQuestionIndex={currentQuestionIndex}
           />
           
         </Wrapper>
@@ -91,7 +97,10 @@ const Questionnaire = () => {
     </>
 
   );
-
+  
+  console.log(`Testing in Questionnaire component. questionStates: ${questionStates}`);
+  console.log(`Testing currentQuestionIndex: ${currentQuestionIndex}`);
+  console.log(`ALSO Testing currentQuestion: ${JSON.stringify(currentQuestion)}`);
   return (
     <>
       {currentQuestionsComponent}

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -5,24 +5,12 @@ import { styled } from 'styled-components'
 import Navbar from '../components/Navbar'
 import axiosInstance from '../axiosInstance'
 
-interface WrapperProps {
-  $show?: boolean;
-  $focus?: boolean;
-}
 
 const QuestionnairePage = styled.div`
+  display: flex;
+  justify-content: center;
   background-color: hsl(180, 47%, 80%);
   height: 100vh;
-`;
-
-
-// This component controls the visibility of the question card:
-const Wrapper = styled.div<WrapperProps>`
-  background-color: transparent;
-  opacity: ${props => (props.$show ? 1 : 0)};
-  transition: color 1s, opacity 1s;
-  color: ${props => (props.$focus ? "black": "transparent")};
-  text-shadow: ${props => (props.$focus ? "0 0 0px" : "0 0 5px rgba(0,0,0,0.5)")};
 `;
 
 
@@ -55,10 +43,6 @@ const Questionnaire = () => {
     }
   ];
 
-  // const isNavbarVisible = false;
-
-  // Initialize questionStates so that only the first QuestionCard is initially displayed
-  //const initialQuestionStates = questionList.map((_, index) => index === 0);
 
   // Hook to verify when question cards have been answered
   const [questionStates, setQuestionStates] = useState([true, false, false, false, false, false])
@@ -67,25 +51,17 @@ const Questionnaire = () => {
 
   const currentQuestion = questionList[currentQuestionIndex];
 
-
   
-  // Check why this property was needed within NavBar component: key={`${index}` + 'NavBar'}
-
-  const currentQuestionsComponent = (
+ 
+  
+  // console.log(`Testing in Questionnaire component. questionStates: ${questionStates}`);
+  // console.log(`Testing currentQuestionIndex: ${currentQuestionIndex}`);
+  // console.log(`ALSO Testing currentQuestion: ${JSON.stringify(currentQuestion.question)}`);
+  return (
     <>
-      {/* <NavBar key={`${currentQuestionIndex}` + 'NavBar'} visible={true}/> */}
-      {/* <Navbar visible={isNavbarVisible}/> */}
-      
-
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-
-        <Wrapper 
-          key={`${currentQuestionIndex}` + 'Wrapper'} 
-          $show={questionStates[currentQuestionIndex]} 
-          $focus={!questionStates[currentQuestionIndex + 1] || currentQuestionIndex === questionStates.length - 1}
-        >
-          
-          <QuestionCard
+      <QuestionnairePage>
+        {/* {currentQuestionsComponent} */}
+        <QuestionCard
             key={currentQuestionIndex} 
             el={currentQuestionIndex} 
             question={currentQuestion.question} 
@@ -95,21 +71,6 @@ const Questionnaire = () => {
             setCurrentQuestionIndex={setCurrentQuestionIndex}
             currentQuestionIndex={currentQuestionIndex}
           />
-          
-        </Wrapper>
-
-      </div>
-    </>
-
-  );
-  
-  console.log(`Testing in Questionnaire component. questionStates: ${questionStates}`);
-  console.log(`Testing currentQuestionIndex: ${currentQuestionIndex}`);
-  console.log(`ALSO Testing currentQuestion: ${JSON.stringify(currentQuestion.question)}`);
-  return (
-    <>
-      <QuestionnairePage>
-        {currentQuestionsComponent}
       </QuestionnairePage>
     </>
   );
@@ -118,7 +79,27 @@ const Questionnaire = () => {
 
 export default Questionnaire;
 
+//opacity: ${props => (props.$show ? 1 : 0)};
+    //transition: color 1s, opacity 1s ease-in-out;
 
+
+// const isNavbarVisible = false;
+ // Check why this property was needed within NavBar component: key={`${index}` + 'NavBar'}
+  {/* <NavBar key={`${currentQuestionIndex}` + 'NavBar'} visible={true}/> */}
+  {/* <Navbar visible={isNavbarVisible}/> */}
+
+// interface WrapperProps {
+//   $show?: boolean;
+//   $focus?: boolean;
+// }
+
+// This component controls the visibility of the question card:
+// const Wrapper = styled.div<WrapperProps>`
+//   //opacity: ${props => (props.$show ? 1 : 0)};
+//   //transition: color 1s, opacity 1s;
+//   //color: ${props => (props.$focus ? "black": "transparent")};
+//   //text-shadow: ${props => (props.$focus ? "0 0 0px" : "0 0 5px rgba(0,0,0,0.5)")};
+// `;
 
 
 // Commenting out card shadow for now since we won't need it. Needing to test other functionality first

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -10,6 +10,11 @@ interface WrapperProps {
   $focus?: boolean;
 }
 
+const QuestionnairePage = styled.div`
+  background-color: hsl(180, 47%, 80%);
+  height: 100vh;
+`;
+
 
 // This component controls the visibility of the question card:
 const Wrapper = styled.div<WrapperProps>`
@@ -100,10 +105,12 @@ const Questionnaire = () => {
   
   console.log(`Testing in Questionnaire component. questionStates: ${questionStates}`);
   console.log(`Testing currentQuestionIndex: ${currentQuestionIndex}`);
-  console.log(`ALSO Testing currentQuestion: ${JSON.stringify(currentQuestion)}`);
+  console.log(`ALSO Testing currentQuestion: ${JSON.stringify(currentQuestion.question)}`);
   return (
     <>
-      {currentQuestionsComponent}
+      <QuestionnairePage>
+        {currentQuestionsComponent}
+      </QuestionnairePage>
     </>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   },
   "include": [
     "./src/**/*",
-    "./server/*"
+    "./server/*",
+    "cypress/**/*.ts",
   ]
 }

--- a/types.ts
+++ b/types.ts
@@ -50,6 +50,8 @@ export type QuestionCardType = {
     type: string,
     setQuestionStates: React.Dispatch<React.SetStateAction<boolean[]>>,
     questionStates: boolean[],
+    setCurrentQuestionIndex: React.Dispatch<React.SetStateAction<number>>,
+    currentQuestionIndex: number,
     // ref: any
 };
 


### PR DESCRIPTION
# Overview

## Task

Same as used in the feature branch

- [X] Bug
- [X] Feature

## Description
- Updated Questionnaire page so that each question card renders one by one
- Updated some styling

## Ticket
#39

**Trello link**
https://trello.com/c/OtfaUJ7X

## Feature Validation / Bug Reproduction Steps

1. npm run start-all
2. Login and click on start 
3. Answer questionnaire cards
4. Check the "Back" button in between question cards to confirm previous question card renders as necessary

## Previous Behavior
- Questionnaire page had a vertical scroll effect
- Lots of negative space due to Question Cards that had opacity of 0, that were being rendered

## Expected Behavior
- Question Cards will now conditionally render one by one
- Ability to transition in back and forth between question cards

## Screenshots & Videos
![QuestionCardUpdate](https://github.com/Travel-T1me/Fernweh/assets/112226540/0b2372e6-0cf0-43dc-b45d-6b8d5a9be701)

## Additional Context
- Navbar was removed from Questionnaire are
- Transition effect between cards is currently not functioning